### PR TITLE
new: keep window after deleting buffer; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Page step, for `PGUP/PGDN/C-f/C-b`.
 - `g:bufferhint_SessionFile`
 Session file name.
 
+- `g:bufferhint_KeepWindow`
+Keep window after using `d` to delete buffer if it's been set to 1.
+
 # Screenshot
 ![bufferhint](https://github.com/bsdelf/bufferhint/raw/master/screenshot_1.png)
 

--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -30,6 +30,10 @@ if !exists('g:bufferhint_SessionFile')
     let g:bufferhint_SessionFile = 'session.vim'
 endif
 
+if !exists('g:bufferhint_KeepWindow')
+	let g:bufferhint_KeepWindow = 0
+endif
+
 " if window height changed,
 " we need to regenerate hits
 let s:Width = 0
@@ -97,7 +101,7 @@ fu! bufferhint#Popup()
         sy clear
         sy match KeyHint /^../
         sy match AtHint /@/
-        hi clear
+        "hi clear
         hi def AtHint ctermfg=red
         let mode = g:bufferhint_SortMode
         if mode == 0
@@ -515,6 +519,89 @@ fu! bufferhint#KillByCursor()
     call s:KillByIndex(idx)
 endfu
 
+fu! bufferhint#BufferKill(bang, buffer)
+	let l:bufcount = bufnr('$')
+	let l:switch = 0 	" window which contains target buffer will be switched
+	if empty(a:buffer)
+		let l:target = bufnr('%')
+	elseif a:buffer =~ '^\d\+$'
+		let l:target = bufnr(str2nr(a:buffer))
+	else
+		let l:target = bufnr(a:buffer)
+	endif
+	if l:target <= 0
+		echohl ErrorMsg
+		echomsg "cannot find buffer: '" . a:buffer . "'"
+		echohl NONE
+		return 0
+	endif
+	if empty(a:bang) && getbufvar(l:target, '&modified')
+		echohl ErrorMsg
+		echomsg "No write since last change (use :BufferKill!)"
+		echohl NONE
+		return 0
+	endif
+	if bufnr('#') > 0	" check alternative buffer
+		let l:aid = bufnr('#')
+		if l:aid != l:target && buflisted(l:aid) && getbufvar(l:aid, "&modifiable")
+			let l:switch = l:aid	" switch to alternative buffer
+		endif
+	endif
+	if l:switch == 0	" check non-scratch buffers
+		let l:index = l:bufcount
+		while l:index >= 0
+			if buflisted(l:index) && getbufvar(l:index, "&modifiable")
+				if strlen(bufname(l:index)) > 0 && l:index != l:target
+					let l:switch = l:index	" switch to that buffer
+					break
+				endif
+			endif
+			let l:index = l:index - 1	
+		endwhile
+	endif
+	if l:switch == 0	" check scratch buffers
+		let l:index = l:bufcount
+		while l:index >= 0
+			if buflisted(l:index) && getbufvar(l:index, "&modifiable")
+				if l:index != l:target
+					let l:switch = l:index	" switch to a scratch
+					break
+				endif
+			endif
+			let l:index = l:index - 1
+		endwhile
+	endif
+	if l:switch  == 0	" check if only one scratch left
+		if strlen(bufname(l:target)) == 0 && (!getbufvar(l:target, "&modified"))
+			echo "This is the last scratch"
+			return 0
+		endif
+	endif
+	let l:ntabs = tabpagenr('$')
+	let l:tabcc = tabpagenr()
+	let l:wincc = winnr()
+	let l:index = 1
+	while l:index <= l:ntabs
+		exec 'tabn '.l:index
+		while 1
+			let l:wid = bufwinnr(l:target)
+			if l:wid <= 0 | break | endif
+			exec l:wid.'wincmd w'
+			if l:switch == 0
+				exec 'enew!'
+				let l:switch = bufnr('%')
+			else
+				exec 'buffer '.l:switch
+			endif
+		endwhile
+		let l:index += 1
+	endwhile
+	exec 'tabn ' . l:tabcc
+	exec l:wincc . 'wincmd w'
+	exec 'bdelete! '.l:target
+	return 1
+endfu
+
 fu! s:KillByIndex(idx)
     let bids = s:GetModeBids()
     if a:idx >= len(bids) || a:idx < 0
@@ -525,8 +612,20 @@ fu! s:KillByIndex(idx)
 
     bwipeout
 
+	if getbufvar(bid, '&modified')
+		echohl ErrorMsg
+		echomsg "No write since last change"
+		echohl NONE
+		return
+	endif
+
     " kill buffer
-    exe "silent bdelete " . bid
+	if !g:bufferhint_KeepWindow
+    	exe "silent bdelete! " . bid
+	else
+		call bufferhint#BufferKill('!', bid)
+	endif
+
     call remove(bids, a:idx)
 
     " update LRU


### PR DESCRIPTION
- Keep window layout while deleting buffer (`let g:bufferhint_KeepWindow = 1`, default is 0)
- Prompt `No write since last change` and exit while attempting delete a modified buffer. Otherwise it will fail into an error state: `bdelete (without !)` failed but `remove(bids, a:idx)` succeeded (in KillByIndex).
- Syntax highlight settings may lost by using `hi clear` in Popup(), which make my LineNr (color of line numbers) setting invalid.
