### PR TITLE
积累更新，bufferhint 更完美了

### DIFF
--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -101,6 +101,7 @@ fu! bufferhint#Popup()
     setlocal nowrap
     setlocal nonumber
     setlocal filetype=bufferhint
+	setlocal signcolumn=no
 
     " syntax highlighting
     if has("syntax")

--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -36,7 +36,7 @@ if !exists('g:bufferhint_BufferName')
 endif
 
 if !exists('g:bufferhint_KeepWindow')
-	let g:bufferhint_KeepWindow = 0
+    let g:bufferhint_KeepWindow = 0
 endif
 
 " if window height changed,
@@ -106,16 +106,16 @@ fu! bufferhint#Popup()
         sy clear
         sy match KeyHint /^../
         sy match AtHint /@/
-		if !get(g:, 'bufferhint_CustomHighlight', '')
-			hi clear KeyHint
-			hi def AtHint ctermfg=red
-			let mode = g:bufferhint_SortMode
-			if mode == 0
-				hi def KeyHint ctermfg=yellow
-			elseif mode == 1
-				hi def KeyHint ctermfg=green
-			endif
-		endif
+        if !get(g:, 'bufferhint_CustomHighlight', '')
+            hi clear KeyHint
+            hi def AtHint ctermfg=red
+            let mode = g:bufferhint_SortMode
+            if mode == 0
+                hi def KeyHint ctermfg=yellow
+            elseif mode == 1
+                hi def KeyHint ctermfg=green
+            endif
+        endif
     endif
 
     " set content
@@ -322,7 +322,7 @@ fu! s:ListBuffer()
     for curline in split(buflist, '\n')
         if curline =~ '^\s*\d\+'
             let bid = str2nr(matchstr(curline, '^\s*\zs\d\+'))
-			let bids += [bid]
+            let bids += [bid]
         endif
     endfor
     return bids
@@ -527,14 +527,14 @@ fu! s:LoadByIndex(idx)
     if bufexists(bufnr(s:MyName))
         exe 'bwipeout ' . bufnr(s:MyName)
     endif
-	try
-		exe "b " . bid
-	catch /^Vim\%((\a\+)\)\=:E37/
-		let pos = stridx(v:exception, ':E')
-		echohl ErrorMsg
-		echo (pos >= 0)? strpart(v:exception, pos + 1) : v:exception
-		echohl None
-	endtry
+    try
+        exe "b " . bid
+    catch /^Vim\%((\a\+)\)\=:E37/
+        let pos = stridx(v:exception, ':E')
+        echohl ErrorMsg
+        echo (pos >= 0)? strpart(v:exception, pos + 1) : v:exception
+        echohl None
+    endtry
 endfu
 
 "--------------------------------------------

--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -95,7 +95,7 @@ fu! bufferhint#Popup()
     setlocal noshowcmd
     setlocal noswapfile
     setlocal buftype=nofile
-    setlocal bufhidden=delete
+    setlocal bufhidden=wipe
     setlocal nobuflisted
     setlocal nomodifiable
     setlocal nowrap

--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -100,7 +100,7 @@ fu! bufferhint#Popup()
     setlocal nomodifiable
     setlocal nowrap
     setlocal nonumber
-	setlocal filetype=bufferhint
+    setlocal filetype=bufferhint
 
     " syntax highlighting
     if has("syntax")

--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -100,6 +100,7 @@ fu! bufferhint#Popup()
     setlocal nomodifiable
     setlocal nowrap
     setlocal nonumber
+	setlocal filetype=bufferhint
 
     " syntax highlighting
     if has("syntax")


### PR DESCRIPTION
**修改1：buffer 列表迭代**

原版取得 buffer 列表使用的是 bid 从 1 开始迭代到 `bufnr('$')` 即最后一个buffer编号，这个做法效率十分底下。Vim 里随便开关个窗口，打开和关闭一次 bufferhint 或者其他插件，id都会增长，调用一次 grep 结果到 quickfix，所有结果指向的文件名都会被批量添加到 buffer list 里面只不过是 unload 状态（ls! 可以查看），所以 Vim 运行久点 `bufnr('%')` 返回的最大编号变成几千上万都很正常。

如果按照传统做法每次打开 bufferhint 都要从 1 迭代到最后一个 id，那效率会随着 Vim运行时间的增加不断下降。所以改为使用 `ls` 命令返回的结果构造有效的 buffer list。

Vim 源代码里，buffer list 是保存在 hash 表里的，同时所有 buffer 都有双向链表串起来，而 Vim 内部迭代 buffer ，包括 ls 命令取得列表，都是双向链表直接 next 到下一个节点的，无效的节点都不会空跑，所以这个更改让 bufferhint 的 buffer list 迭代性能变成了常数，不会随最大 bid 增长而变慢。

**修改2：解决切换未保存的buffer时出错**

如果一个 buffer 修改过没有保存，同时 vim 里面没有打开 hidden 选项，那么用 bufferhint 切走它时，就会爆一堆错误，所以加个判断来处理这个边界条件。

**修改3：允许自定义 highlight**

增加一个 bufferhint_CustomHighlight 选项，如果设置成1，则 bufferhint 不会每次修改 highlight。
因为大家背景颜色不一样，我的 Vim 现在开始切换成白色主题的配色了，原有 bufferhint 的颜色在白色主题下很难看，有这个选项，我可以外面方便的定制修改颜色。


