### PR TITLE
fixed: "signcolumn=no" is incompatible with old Vim versions.

### DIFF
--- a/plugin/bufferhint.vim
+++ b/plugin/bufferhint.vim
@@ -101,7 +101,9 @@ fu! bufferhint#Popup()
     setlocal nowrap
     setlocal nonumber
     setlocal filetype=bufferhint
-	setlocal signcolumn=no
+	if has('patch-7.4.2210')
+		setlocal signcolumn=no
+	endif
 
     " syntax highlighting
     if has("syntax")


### PR DESCRIPTION
不好意思，

```VimL
setlocal signcolumn=no
```

这个东西，vim7.4.2201 以后才开始有，增加了兼容判断。